### PR TITLE
compensated_readings: make 'timestamp' tz-aware.

### DIFF
--- a/bme280/__init__.py
+++ b/bme280/__init__.py
@@ -77,7 +77,7 @@ class compensated_readings(object):
         self._comp = compensation_params
         self.id = uuid.uuid4()
         self.uncompensated = raw_readings
-        self.timestamp = datetime.datetime.now()
+        self.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         self.temperature = self.__tfine(raw_readings.temperature) / 5120.0
         self.humidity = self.__calc_humidity(raw_readings.humidity,
                                              raw_readings.temperature)

--- a/bme280/__init__.py
+++ b/bme280/__init__.py
@@ -35,6 +35,7 @@ import uuid
 
 from bme280.reader import reader
 import bme280.const as oversampling
+import pytz
 
 # Oversampling modes
 oversampling.x1 = 1
@@ -77,7 +78,7 @@ class compensated_readings(object):
         self._comp = compensation_params
         self.id = uuid.uuid4()
         self.uncompensated = raw_readings
-        self.timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.timestamp = datetime.datetime.utcnow().replace(tzinfo=pytz.UTC)
         self.temperature = self.__tfine(raw_readings.temperature) / 5120.0
         self.humidity = self.__calc_humidity(raw_readings.humidity,
                                              raw_readings.temperature)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python
 
 import os
+import re
 import sys
 from setuptools import setup
 
-import bme280
+here = os.path.dirname(__file__)
 
-README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+README = open(os.path.join(here, 'README.rst')).read()
+
+
+def _read_version():
+    with open(os.path.join(here, 'bme280', '__init__.py')) as code:
+        contents = code.read()
+    match = re.search(r'__version__\s*=\s*["\'](.*?)["\']', contents)
+    return match.group(1)
+
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
@@ -16,9 +25,11 @@ test_deps = [
     'pytest-cov'
 ]
 
+version = _read_version()
+
 setup(
     name="RPi.bme280",
-    version=bme280.__version__,
+    version=version,
     author="Richard Hull",
     author_email="richard.hull@destructuring-bind.org",
     description="A library to drive a Bosch BME280 temperature, humidity, pressure sensor over I2C",
@@ -26,7 +37,7 @@ setup(
     license="MIT",
     keywords=["raspberry pi", "orange pi", "banana pi", "rpi", "bosch", "BME280", "i2c", "temperature", "humidity", "pressure"],
     url="https://github.com/rm-hull/bme280",
-    download_url="https://github.com/rm-hull/bme280/tarball/" + bme280.__version__,
+    download_url="https://github.com/rm-hull/bme280/tarball/" + version,
     packages=['bme280'],
     install_requires=["pytz", "smbus2"],
     setup_requires=pytest_runner,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url="https://github.com/rm-hull/bme280",
     download_url="https://github.com/rm-hull/bme280/tarball/" + bme280.__version__,
     packages=['bme280'],
-    install_requires=["smbus2"],
+    install_requires=["pytz", "smbus2"],
     setup_requires=pytest_runner,
     tests_require=test_deps,
     extras_require={

--- a/tests/test_bme280.py
+++ b/tests/test_bme280.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from mock import Mock, MagicMock  # noqa: F401
 
-from datetime import datetime
+from datetime import datetime, timezone
 import bme280
 
 smbus = Mock(unsafe=True)
@@ -101,8 +101,8 @@ def test_compensated_readings_repr():
     raw = bme280.uncompensated_readings(block)
     reading = bme280.compensated_readings(raw, compensation_params)
     reading.id = "55fea298-5a5d-4873-a46d-b631c8748100"
-    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14, 206233)
-    assert repr(reading) == "compensated_reading(id=55fea298-5a5d-4873-a46d-b631c8748100, timestamp=2018-03-18 19:26:14.206233, temp=0.003 °C, pressure=8758647.58 hPa, humidity=0.05 % rH)"
+    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14, 206233, tzinfo=timezone.utc)
+    assert repr(reading) == "compensated_reading(id=55fea298-5a5d-4873-a46d-b631c8748100, timestamp=2018-03-18 19:26:14.206233UTC, temp=0.003 °C, pressure=8758647.58 hPa, humidity=0.05 % rH)"
 
 
 def test_compensated_readings_repr_zero_millis():
@@ -110,5 +110,5 @@ def test_compensated_readings_repr_zero_millis():
     raw = bme280.uncompensated_readings(block)
     reading = bme280.compensated_readings(raw, compensation_params)
     reading.id = "55fea298-5a5d-4873-a46d-b631c8748100"
-    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14)
-    assert repr(reading) == "compensated_reading(id=55fea298-5a5d-4873-a46d-b631c8748100, timestamp=2018-03-18 19:26:14.000000, temp=0.003 °C, pressure=8758647.58 hPa, humidity=0.05 % rH)"
+    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14, tzinfo=timezone.utc)
+    assert repr(reading) == "compensated_reading(id=55fea298-5a5d-4873-a46d-b631c8748100, timestamp=2018-03-18 19:26:14.000000UTC, temp=0.003 °C, pressure=8758647.58 hPa, humidity=0.05 % rH)"

--- a/tests/test_bme280.py
+++ b/tests/test_bme280.py
@@ -8,8 +8,9 @@ try:
 except ImportError:
     from mock import Mock, MagicMock  # noqa: F401
 
-from datetime import datetime, timezone
+from datetime import datetime
 import bme280
+import pytz
 
 smbus = Mock(unsafe=True)
 
@@ -101,7 +102,7 @@ def test_compensated_readings_repr():
     raw = bme280.uncompensated_readings(block)
     reading = bme280.compensated_readings(raw, compensation_params)
     reading.id = "55fea298-5a5d-4873-a46d-b631c8748100"
-    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14, 206233, tzinfo=timezone.utc)
+    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14, 206233, tzinfo=pytz.UTC)
     assert repr(reading) == "compensated_reading(id=55fea298-5a5d-4873-a46d-b631c8748100, timestamp=2018-03-18 19:26:14.206233UTC, temp=0.003 °C, pressure=8758647.58 hPa, humidity=0.05 % rH)"
 
 
@@ -110,5 +111,5 @@ def test_compensated_readings_repr_zero_millis():
     raw = bme280.uncompensated_readings(block)
     reading = bme280.compensated_readings(raw, compensation_params)
     reading.id = "55fea298-5a5d-4873-a46d-b631c8748100"
-    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14, tzinfo=timezone.utc)
+    reading.timestamp = datetime(2018, 3, 18, 19, 26, 14, tzinfo=pytz.UTC)
     assert repr(reading) == "compensated_reading(id=55fea298-5a5d-4873-a46d-b631c8748100, timestamp=2018-03-18 19:26:14.000000UTC, temp=0.003 °C, pressure=8758647.58 hPa, humidity=0.05 % rH)"


### PR DESCRIPTION
The 'timestamp' object in the compensated_readings class was prevously "naive", meaning it did not have any timezone information and was therefore ambiguous. This change explicitly sets the timezone to UTC.

This has the disadvantage that a new user may be confused upon seeing a timestamp that is not what they expected (UTC rather than their local timezone), but in my experience the benefit of having a universally correct and unambiguous timestamp *vastly* outweighs this.